### PR TITLE
Update unico-webframe to v3.21.0 - deleted

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.0",
     "lucide-react": "^0.330.0",
-    "unico-webframe": "3.20.10"
+    "unico-webframe": "3.21.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.1",


### PR DESCRIPTION

    Automatic update of `unico-webframe` to version **3.21.0** 📅 Release date: **09/09/2025** 🔗 [Official Release Notes](https://devcenter.unico.io/idcloud/integracao/sdk/integracao-sdks/sdk-web/release-notes)
    