### PR TITLE
fix: create unique branch per run to avoid git push conflicts

### DIFF
--- a/scripts/update_unico_target.py
+++ b/scripts/update_unico_target.py
@@ -57,7 +57,7 @@ if current_version != site_version:
 
     print(f"✅ Updated {DEPENDENCY} to version {site_version}")
 
-    branch = f"update-{DEPENDENCY}-v{site_version}"
+    branch = f"update-{DEPENDENCY}-v{site_version}-{timestamp}"
     tag = f"{DEPENDENCY}-v{site_version}"
 
     # Create branch, commit, and push changes


### PR DESCRIPTION
# Description

- Added timestamp to branch name to ensure uniqueness
- Prevents push rejection when remote branch already exists
- Keeps commit, tag, and PR creation flow intact

# Demand

What demand does this Pull Request refer to?

- [ ] Bug
- [ ] Feature
- [X] update